### PR TITLE
nf_conntrack_maxを1000000に設定

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ fi
 BASEDIR="$(cd $(dirname $0); pwd)"
 DISKIMAGE_BUILDER_VERSION="2.18.0"
 OCTAVIA_VERSION=${1:-"3.0.1"}
-CUSTOM_ELEMENTS=${CUSTOM_ELEMENTS:-"timezone sync-hwclock keepalived-status-check"}
+CUSTOM_ELEMENTS=${CUSTOM_ELEMENTS:-"timezone sync-hwclock keepalived-status-check kernel-modules"}
 
 echo + git clone octavia repository
 [ ! -d "octavia" ] && git clone https://github.com/openstack/octavia.git

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ fi
 BASEDIR="$(cd $(dirname $0); pwd)"
 DISKIMAGE_BUILDER_VERSION="2.18.0"
 OCTAVIA_VERSION=${1:-"3.0.1"}
-CUSTOM_ELEMENTS=${CUSTOM_ELEMENTS:-"timezone sync-hwclock keepalived-status-check kernel-modules"}
+CUSTOM_ELEMENTS=${CUSTOM_ELEMENTS:-"timezone sync-hwclock keepalived-status-check tune-kernel"}
 
 echo + git clone octavia repository
 [ ! -d "octavia" ] && git clone https://github.com/openstack/octavia.git

--- a/elements/kernel-modules/post-install.d/10-nf_conntrack_max
+++ b/elements/kernel-modules/post-install.d/10-nf_conntrack_max
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# nf_conntrack is loaded on system start before sysctl executed.
+echo 'nf_conntrack' >> /etc/modules
+
+# set nf_conntrack_max.
+echo 'net.netfilter.nf_conntrack_max=1000000' >> /etc/sysctl.conf

--- a/elements/kernel-modules/post-install.d/10-nf_conntrack_max
+++ b/elements/kernel-modules/post-install.d/10-nf_conntrack_max
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# nf_conntrack is loaded on system start before sysctl executed.
-echo 'nf_conntrack' >> /etc/modules
-
-# set nf_conntrack_max.
-echo 'net.netfilter.nf_conntrack_max=1000000' >> /etc/sysctl.conf

--- a/elements/tune-kernel/post-install.d/10-tune-kernel
+++ b/elements/tune-kernel/post-install.d/10-tune-kernel
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+sysctl-write-value "net.netfilter.nf_conntrack_max" 1000000


### PR DESCRIPTION
デフォルトのnf_conntrackの上限(31740)に達してパケットがドロップされてしまうため、十分大きな値を設定するようにします。