### PR TITLE
net.ipv4.tcp_mem を十分大きな値に設定する

### DIFF
--- a/elements/tune-kernel/post-install.d/10-tune-kernel
+++ b/elements/tune-kernel/post-install.d/10-tune-kernel
@@ -4,4 +4,4 @@ set -eu
 set -o pipefail
 
 sysctl-write-value "net.netfilter.nf_conntrack_max" 1000000
-sysctl-write-value "net.ipv4.tcp_mem" "2048000 2048000 2048000"
+sysctl-write-value "net.ipv4.tcp_mem" "404622 566470 809244"

--- a/elements/tune-kernel/post-install.d/10-tune-kernel
+++ b/elements/tune-kernel/post-install.d/10-tune-kernel
@@ -4,3 +4,4 @@ set -eu
 set -o pipefail
 
 sysctl-write-value "net.netfilter.nf_conntrack_max" 1000000
+sysctl-write-value "net.ipv4.tcp_mem" "2048000 2048000 2048000"


### PR DESCRIPTION
自動で設定される値だとTCPソケットバッファーが溢れてしまうため、十分大きな値を設定します。