### PR TITLE
ubuntu で keepalived_status_check.py が動作しない問題を解決

### DIFF
--- a/elements/keepalived-status-check/pre-install.d/10-keepalived-status-check-install
+++ b/elements/keepalived-status-check/pre-install.d/10-keepalived-status-check-install
@@ -8,8 +8,10 @@ set -o pipefail
 
 mkdir /etc/cron.d
 install -m 0755 -o root -g root $(dirname $0)/keepalived_status_check.py /usr/local/bin/keepalived_status_check.py
+install -m 0755 -o root -g root $(dirname $0)/keepalived_status_check.py.sh /usr/local/bin/keepalived_status_check.py.sh
 install -m 0755 -o root -g root $(dirname $0)/status_check.py /usr/local/bin/status_check.py
 install -m 0644 -o root -g root $(dirname $0)/minutely_status_check /etc/cron.d/minutely_status_check
+install -m 0644 -o root -g root $(dirname $0)/sudoers_syslog /etc/sudoers.d/syslog
 sed -i -e 's,%%{OS_USERNAME}%%,'${OS_USERNAME}',g' \
        -e 's,%%{OS_PASSWORD}%%,'${OS_PASSWORD}',g' \
        -e 's,%%{OS_AUTH_URL}%%,'${OS_AUTH_URL}',g' \

--- a/elements/keepalived-status-check/pre-install.d/10-keepalived-status-check-install
+++ b/elements/keepalived-status-check/pre-install.d/10-keepalived-status-check-install
@@ -11,7 +11,7 @@ install -m 0755 -o root -g root $(dirname $0)/keepalived_status_check.py /usr/lo
 install -m 0755 -o root -g root $(dirname $0)/keepalived_status_check.py.sh /usr/local/bin/keepalived_status_check.py.sh
 install -m 0755 -o root -g root $(dirname $0)/status_check.py /usr/local/bin/status_check.py
 install -m 0644 -o root -g root $(dirname $0)/minutely_status_check /etc/cron.d/minutely_status_check
-install -m 0 -o root -g root $(dirname $0)/sudoers_syslog /etc/sudoers.d/syslog
+install -m 0440 -o root -g root $(dirname $0)/sudoers_syslog /etc/sudoers.d/syslog
 sed -i -e 's,%%{OS_USERNAME}%%,'${OS_USERNAME}',g' \
        -e 's,%%{OS_PASSWORD}%%,'${OS_PASSWORD}',g' \
        -e 's,%%{OS_AUTH_URL}%%,'${OS_AUTH_URL}',g' \

--- a/elements/keepalived-status-check/pre-install.d/10-keepalived-status-check-install
+++ b/elements/keepalived-status-check/pre-install.d/10-keepalived-status-check-install
@@ -11,7 +11,7 @@ install -m 0755 -o root -g root $(dirname $0)/keepalived_status_check.py /usr/lo
 install -m 0755 -o root -g root $(dirname $0)/keepalived_status_check.py.sh /usr/local/bin/keepalived_status_check.py.sh
 install -m 0755 -o root -g root $(dirname $0)/status_check.py /usr/local/bin/status_check.py
 install -m 0644 -o root -g root $(dirname $0)/minutely_status_check /etc/cron.d/minutely_status_check
-install -m 0644 -o root -g root $(dirname $0)/sudoers_syslog /etc/sudoers.d/syslog
+install -m 0 -o root -g root $(dirname $0)/sudoers_syslog /etc/sudoers.d/syslog
 sed -i -e 's,%%{OS_USERNAME}%%,'${OS_USERNAME}',g' \
        -e 's,%%{OS_PASSWORD}%%,'${OS_PASSWORD}',g' \
        -e 's,%%{OS_AUTH_URL}%%,'${OS_AUTH_URL}',g' \

--- a/elements/keepalived-status-check/pre-install.d/keepalived_status_check.py.sh
+++ b/elements/keepalived-status-check/pre-install.d/keepalived_status_check.py.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo /usr/local/bin/keepalived_status_check.py

--- a/elements/keepalived-status-check/pre-install.d/sudoers_syslog
+++ b/elements/keepalived-status-check/pre-install.d/sudoers_syslog
@@ -1,0 +1,1 @@
+syslog    ALL=NOPASSWD: /usr/local/bin/keepalived_status_check.py

--- a/elements/keepalived-status-check/static/etc/rsyslog.d/10-keepalived_status_check.conf
+++ b/elements/keepalived-status-check/static/etc/rsyslog.d/10-keepalived_status_check.conf
@@ -1,4 +1,4 @@
 module(load="omprog")
 if($programname == "Keepalived_vrrp" and $msg contains "Entering MASTER STATE") then {
-  action(type="omprog" binary="/usr/local/bin/keepalived_status_check.py")
+  action(type="omprog" binary="/usr/local/bin/keepalived_status_check.py.sh")
 }


### PR DESCRIPTION
refs: https://github.com/buty4649/amphora-image-builder/issues/10

ubuntu では、rsyslog が  syslog user で動作しているため、 keepalived に対して sigusr1 を投げることができない。
syslog user に権限を少しだけ与えることによりこれを回避する