### PR TITLE
haproxy.logのローテートを毎時にする

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ fi
 BASEDIR="$(cd $(dirname $0); pwd)"
 DISKIMAGE_BUILDER_VERSION="2.29.1"
 OCTAVIA_VERSION=${1:-"5.0.0"}
-CUSTOM_ELEMENTS=${CUSTOM_ELEMENTS:-"timezone sync-hwclock keepalived-status-check tune-kernel"}
+CUSTOM_ELEMENTS=${CUSTOM_ELEMENTS:-"timezone sync-hwclock keepalived-status-check tune-kernel improve-haproxy-logrotate"}
 DISTRO=${DISTRO:-"bionic"}
 
 echo + git clone octavia repository

--- a/elements/improve-haproxy-logrotate/element-deps
+++ b/elements/improve-haproxy-logrotate/element-deps
@@ -1,0 +1,2 @@
+install-static
+haproxy-octavia

--- a/elements/improve-haproxy-logrotate/post-install.d/99-move-logrotate
+++ b/elements/improve-haproxy-logrotate/post-install.d/99-move-logrotate
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-1} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+mv -v /etc/cron.daily/logrotate /etc/cron.hourly

--- a/elements/improve-haproxy-logrotate/static/etc/logrotate.d/haproxy
+++ b/elements/improve-haproxy-logrotate/static/etc/logrotate.d/haproxy
@@ -1,0 +1,11 @@
+/var/log/haproxy.log {
+    hourly
+    rotate 168
+    missingok
+    notifempty
+    compress
+    delaycompress
+    postrotate
+        invoke-rc.d rsyslog rotate >/dev/null 2>&1 || true
+    endscript
+}


### PR DESCRIPTION
大規模なサービスで利用するとhaproxy.logがかなり巨大になっていまい、ディスクフルを引き起こしてしまう。
毎時にローテートに変更することでこの問題を解決する。